### PR TITLE
Fix dispaly image file path

### DIFF
--- a/HomeworkManager/ViewController.swift
+++ b/HomeworkManager/ViewController.swift
@@ -132,7 +132,9 @@ class ViewController: UIViewController, UITableViewDelegate, UITableViewDataSour
         if let photo = realm.findBy(Photo.self, filter: NSPredicate(format: "createdAt == %@", date)) {
             cameraButton.enabled = false
             self.photo = photo
-            let appearImage = UIImage(contentsOfFile: photo.url)
+            let dir = NSSearchPathForDirectoriesInDomains(.DocumentDirectory, .UserDomainMask, true)[0]
+            let photoUrl = NSURL(fileURLWithPath: dir).URLByAppendingPathComponent("images")?.URLByAppendingPathComponent((photo.url as NSString).lastPathComponent)
+            let appearImage = UIImage(contentsOfFile: photoUrl!.path!)
             let imageView = UIImageView(image: appearImage)
             imageView.frame = calcImageFrame()
             imageView.userInteractionEnabled = true


### PR DESCRIPTION
close: #96

[ココらへんの問題](http://stackoverflow.com/questions/26988024/document-or-cache-path-changes-on-every-launch-in-ios-8)によって保存先が追えていなかったため、修正しました。